### PR TITLE
Fix: ByteBuffer allocating

### DIFF
--- a/src/main/java/io/graversen/minecraft/rcon/MinecraftClient.java
+++ b/src/main/java/io/graversen/minecraft/rcon/MinecraftClient.java
@@ -147,10 +147,10 @@ public class MinecraftClient implements IMinecraftClient {
 
     private ByteBuffer createRconByteBuffer(int requestCount, int requestType, String command) {
         // In accordance with the RCON format: Length + Request ID + Type + Payload + Two nil bytes
-        ByteBuffer byteBuffer = ByteBuffer.allocate((3 * Integer.BYTES) + command.length() + (2 * Byte.BYTES));
+        ByteBuffer byteBuffer = ByteBuffer.allocate((3 * Integer.BYTES) + command.getBytes().length + (2 * Byte.BYTES));
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
-        byteBuffer.putInt((2 * Integer.BYTES) + command.length() + (2 * Byte.BYTES));
+        byteBuffer.putInt((2 * Integer.BYTES) + command.getBytes().length + (2 * Byte.BYTES));
         byteBuffer.putInt(requestCount);
         byteBuffer.putInt(requestType);
         byteBuffer.put(command.getBytes());


### PR DESCRIPTION
Thank you for developing useful library. 🙏
I found a small problem about Converting String - Byte.

For Example, Korean language is 3 bytes per 1 letter, so existing code occurred overflow when Korean language came into the command.

- Update MinecraftClient.createRconByteBuffer `command.length()` to `command.getBytes().length` 
